### PR TITLE
fix: use postinstall instead of prepare for bob build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Build package
-        run: yarn prepare
+        run: yarn postinstall
 
   build-android:
     runs-on: ubuntu-latest
@@ -81,8 +81,8 @@ jobs:
         if: env.turbo_cache_hit != 1
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
-          java-version: '17'
+          distribution: "zulu"
+          java-version: "17"
 
       - name: Finalize Android SDK
         if: env.turbo_cache_hit != 1
@@ -96,7 +96,9 @@ jobs:
           path: |
             ~/.gradle/wrapper
             ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('example/android/gradle/wrapper/gradle-wrapper.properties') }}
+          key: ${{ runner.os }}-gradle-${{
+            hashFiles('example/android/gradle/wrapper/gradle-wrapper.properties')
+            }}
           restore-keys: |
             ${{ runner.os }}-gradle-
 
@@ -145,7 +147,8 @@ jobs:
             ${{ runner.os }}-cocoapods-
 
       - name: Install cocoapods
-        if: env.turbo_cache_hit != 1 && steps.cocoapods-cache.outputs.cache-hit != 'true'
+        if: env.turbo_cache_hit != 1 && steps.cocoapods-cache.outputs.cache-hit !=
+          'true'
         run: |
           cd example/ios
           pod install

--- a/android/src/main/java/com/zebralinkos/ZebraLinkosModule.kt
+++ b/android/src/main/java/com/zebralinkos/ZebraLinkosModule.kt
@@ -38,10 +38,10 @@ import com.zebra.sdk.printer.discovery.UsbDiscoverer
 
 @ReactModule(name = ZebraLinkosModule.NAME)
 class ZebraLinkosModule internal constructor(reactContext: ReactApplicationContext) :
-    ZebraLinkosSpec(reactContext) {
+        ZebraLinkosSpec(reactContext) {
 
   private val usbManager =
-      this.reactApplicationContext.getSystemService(Context.USB_SERVICE) as UsbManager
+          this.reactApplicationContext.getSystemService(Context.USB_SERVICE) as UsbManager
   private val ACTION_USB_PERMISSION = "com.android.example.USB_PERMISSION"
   //  Handles USB permission requests
   private var usbReceiverRegistered = false
@@ -51,54 +51,61 @@ class ZebraLinkosModule internal constructor(reactContext: ReactApplicationConte
   private var pendingPermissionPromise: Promise? = null
 
   private val usbReceiver =
-      object : BroadcastReceiver() {
-        override fun onReceive(context: Context, intent: Intent) {
-          if (intent.action == ACTION_USB_PERMISSION) {
-            val device: UsbDevice? = intent.getParcelableExtra(UsbManager.EXTRA_DEVICE)
-            val granted = intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false)
-            val mode = intent.getStringExtra("Mode")
-            val deviceId = intent.getStringExtra("deviceId")
+          object : BroadcastReceiver() {
+            override fun onReceive(context: Context, intent: Intent) {
+              if (intent.action == ACTION_USB_PERMISSION) {
+                val device: UsbDevice? = intent.getParcelableExtra(UsbManager.EXTRA_DEVICE)
+                val granted = intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false)
+                val mode = intent.getStringExtra("Mode")
+                val deviceId = intent.getStringExtra("deviceId")
 
-            Log.d(
-                NAME,
-                "USB permission received for device: ${device?.productName}, granted: $granted")
+                Log.d(
+                        NAME,
+                        "USB permission received for device: ${device?.productName}, granted: $granted"
+                )
 
-            if (granted) {
-              if (pendingPermissionPromise != null) {
-                pendingPermissionPromise?.resolve(true)
-              } else if (device != null) {
-                when (mode) {
-                  "Status" -> {
-                    return checkUsbStatusNow(deviceId ?: device.deviceName, device, pendingPromise)
+                if (granted) {
+                  if (pendingPermissionPromise != null) {
+                    pendingPermissionPromise?.resolve(true)
+                  } else if (device != null) {
+                    when (mode) {
+                      "Status" -> {
+                        return checkUsbStatusNow(
+                                deviceId ?: device.deviceName,
+                                device,
+                                pendingPromise
+                        )
+                      }
+                      "Print" -> {
+                        return writeToUsbNow(device, pendingZpl, pendingPromise)
+                      }
+                      else -> {
+                        Log.e(NAME, "Unknown mode: $mode")
+                        pendingPromise?.reject("E_USB_MODE", "Unknown USB mode: $mode")
+                        return
+                      }
+                    }
                   }
-                  "Print" -> {
-                    return writeToUsbNow(device, pendingZpl, pendingPromise)
-                  }
-                  else -> {
-                    Log.e(NAME, "Unknown mode: $mode")
-                    pendingPromise?.reject("E_USB_MODE", "Unknown USB mode: $mode")
-                    return
-                  }
+                } else {
+                  pendingPermissionPromise?.reject(
+                          "E_USB_PERMISSION_DENIED",
+                          "USB permission denied by user"
+                  )
+                  pendingPromise?.reject("E_USB_PERMISSION_DENIED", "USB permission denied by user")
                 }
+
+                // Clean up
+                pendingDevice = null
+                pendingPromise = null
+                pendingPermissionPromise = null
+
+                try {
+                  context.unregisterReceiver(this)
+                } catch (_: Exception) {}
+                usbReceiverRegistered = false
               }
-            } else {
-              pendingPermissionPromise?.reject(
-                  "E_USB_PERMISSION_DENIED", "USB permission denied by user")
-              pendingPromise?.reject("E_USB_PERMISSION_DENIED", "USB permission denied by user")
             }
-
-            // Clean up
-            pendingDevice = null
-            pendingPromise = null
-            pendingPermissionPromise = null
-
-            try {
-              context.unregisterReceiver(this)
-            } catch (_: Exception) {}
-            usbReceiverRegistered = false
           }
-        }
-      }
 
   override fun getName(): String {
     return NAME
@@ -219,20 +226,28 @@ class ZebraLinkosModule internal constructor(reactContext: ReactApplicationConte
       if (!usbReceiverRegistered) {
         val filter = IntentFilter(ACTION_USB_PERMISSION)
         ContextCompat.registerReceiver(
-            reactApplicationContext, usbReceiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
+                reactApplicationContext,
+                usbReceiver,
+                filter,
+                ContextCompat.RECEIVER_NOT_EXPORTED
+        )
         usbReceiverRegistered = true
       }
 
       val explicitIntent =
-          Intent(ACTION_USB_PERMISSION).apply {
-            setPackage(reactApplicationContext.packageName)
-            putExtra(UsbManager.EXTRA_DEVICE, device)
-            putExtra("Mode", "Print")
-          }
+              Intent(ACTION_USB_PERMISSION).apply {
+                setPackage(reactApplicationContext.packageName)
+                putExtra(UsbManager.EXTRA_DEVICE, device)
+                putExtra("Mode", "Print")
+              }
 
       val permissionIntent =
-          PendingIntent.getBroadcast(
-              reactApplicationContext, 0, explicitIntent, PendingIntent.FLAG_MUTABLE)
+              PendingIntent.getBroadcast(
+                      reactApplicationContext,
+                      0,
+                      explicitIntent,
+                      PendingIntent.FLAG_MUTABLE
+              )
 
       usbManager.requestPermission(device, permissionIntent)
     }
@@ -247,19 +262,19 @@ class ZebraLinkosModule internal constructor(reactContext: ReactApplicationConte
     }
 
     val device =
-        deviceList[deviceId]
-            ?: run {
-              Log.e(NAME, "USB device with ID $deviceId is null")
-              return null
-            }
+            deviceList[deviceId]
+                    ?: run {
+                      Log.e(NAME, "USB device with ID $deviceId is null")
+                      return null
+                    }
 
     return device
   }
 
   private fun writeToUsbNow(
-      device: UsbDevice,
-      zpl: String? = pendingZpl,
-      promise: Promise? = pendingPromise
+          device: UsbDevice,
+          zpl: String? = pendingZpl,
+          promise: Promise? = pendingPromise
   ) {
     val printerConnection = UsbConnection(usbManager, device)
 
@@ -289,9 +304,9 @@ class ZebraLinkosModule internal constructor(reactContext: ReactApplicationConte
   }
 
   private fun checkUsbStatusNow(
-      deviceId: String,
-      device: UsbDevice,
-      promise: Promise? = pendingPromise
+          deviceId: String,
+          device: UsbDevice,
+          promise: Promise? = pendingPromise
   ) {
     val conn = UsbConnection(usbManager, device)
     try {
@@ -349,19 +364,27 @@ class ZebraLinkosModule internal constructor(reactContext: ReactApplicationConte
       if (!usbReceiverRegistered) {
         val filter = IntentFilter(ACTION_USB_PERMISSION)
         ContextCompat.registerReceiver(
-            reactApplicationContext, usbReceiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
+                reactApplicationContext,
+                usbReceiver,
+                filter,
+                ContextCompat.RECEIVER_NOT_EXPORTED
+        )
         usbReceiverRegistered = true
       }
 
       val explicitIntent =
-          Intent(ACTION_USB_PERMISSION).apply {
-            setPackage(reactApplicationContext.packageName)
-            putExtra(UsbManager.EXTRA_DEVICE, device)
-          }
+              Intent(ACTION_USB_PERMISSION).apply {
+                setPackage(reactApplicationContext.packageName)
+                putExtra(UsbManager.EXTRA_DEVICE, device)
+              }
 
       val permissionIntent =
-          PendingIntent.getBroadcast(
-              reactApplicationContext, 0, explicitIntent, PendingIntent.FLAG_MUTABLE)
+              PendingIntent.getBroadcast(
+                      reactApplicationContext,
+                      0,
+                      explicitIntent,
+                      PendingIntent.FLAG_MUTABLE
+              )
 
       usbManager.requestPermission(device, permissionIntent)
     }
@@ -377,33 +400,33 @@ class ZebraLinkosModule internal constructor(reactContext: ReactApplicationConte
     }
 
     val discoveryHandler =
-        object : DiscoveryHandler {
-          val printers = Arguments.createArray()
+            object : DiscoveryHandler {
+              val printers = Arguments.createArray()
 
-          override fun foundPrinter(printer: DiscoveredPrinter) {
-            try {
-              Log.d(NAME, "Found printer: $printer")
-              val printerNetwork = printer as DiscoveredPrinterNetwork
-              this.printers.pushMap(convertToWritableMap(printerNetwork))
-              Log.d(NAME, "Found printer: ${printerNetwork.address}")
-            } catch (e: Exception) {
-              Log.e(NAME, "Error adding printer to list: ${e.localizedMessage}")
-              promise.reject("E_NET_SCAN", e.localizedMessage, e)
-              e.localizedMessage?.let { Log.e(NAME, it) }
-              e.printStackTrace()
+              override fun foundPrinter(printer: DiscoveredPrinter) {
+                try {
+                  Log.d(NAME, "Found printer: $printer")
+                  val printerNetwork = printer as DiscoveredPrinterNetwork
+                  this.printers.pushMap(convertToWritableMap(printerNetwork))
+                  Log.d(NAME, "Found printer: ${printerNetwork.address}")
+                } catch (e: Exception) {
+                  Log.e(NAME, "Error adding printer to list: ${e.localizedMessage}")
+                  promise.reject("E_NET_SCAN", e.localizedMessage, e)
+                  e.localizedMessage?.let { Log.e(NAME, it) }
+                  e.printStackTrace()
+                }
+              }
+
+              override fun discoveryFinished() {
+                Log.d(NAME, "Discovery finished")
+                promise.resolve(this.printers)
+              }
+
+              override fun discoveryError(message: String?) {
+                Log.e(NAME, "Network discovery error: $message")
+                promise.reject("E_NET_SCAN", message)
+              }
             }
-          }
-
-          override fun discoveryFinished() {
-            Log.d(NAME, "Discovery finished")
-            promise.resolve(this.printers)
-          }
-
-          override fun discoveryError(message: String?) {
-            Log.e(NAME, "Network discovery error: $message")
-            promise.reject("E_NET_SCAN", message)
-          }
-        }
 
     try {
       Log.d(NAME, "Going to scan network")
@@ -427,32 +450,32 @@ class ZebraLinkosModule internal constructor(reactContext: ReactApplicationConte
     }
 
     val discoveryHandler =
-        object : DiscoveryHandler {
-          val printers = Arguments.createArray()
+            object : DiscoveryHandler {
+              val printers = Arguments.createArray()
 
-          override fun foundPrinter(printer: DiscoveredPrinter) {
-            try {
-              val printerBluetooth = printer as DiscoveredPrinterBluetooth
-              this.printers.pushMap(convertToWritableMap(printerBluetooth))
-              Log.d(NAME, "Found printer: ${printerBluetooth.friendlyName}")
-            } catch (e: Exception) {
-              Log.e(NAME, "Error adding printer to list: ${e.localizedMessage}")
-              promise.reject("E_BT_SCAN", e.localizedMessage, e)
-              e.localizedMessage?.let { Log.e(NAME, it) }
-              e.printStackTrace()
+              override fun foundPrinter(printer: DiscoveredPrinter) {
+                try {
+                  val printerBluetooth = printer as DiscoveredPrinterBluetooth
+                  this.printers.pushMap(convertToWritableMap(printerBluetooth))
+                  Log.d(NAME, "Found printer: ${printerBluetooth.friendlyName}")
+                } catch (e: Exception) {
+                  Log.e(NAME, "Error adding printer to list: ${e.localizedMessage}")
+                  promise.reject("E_BT_SCAN", e.localizedMessage, e)
+                  e.localizedMessage?.let { Log.e(NAME, it) }
+                  e.printStackTrace()
+                }
+              }
+
+              override fun discoveryFinished() {
+                Log.d(NAME, "Discovery finished")
+                promise.resolve(this.printers)
+              }
+
+              override fun discoveryError(message: String?) {
+                Log.e(NAME, "Bluetooth discovery error: $message")
+                promise.reject("E_BT_SCAN", message)
+              }
             }
-          }
-
-          override fun discoveryFinished() {
-            Log.d(NAME, "Discovery finished")
-            promise.resolve(this.printers)
-          }
-
-          override fun discoveryError(message: String?) {
-            Log.e(NAME, "Bluetooth discovery error: $message")
-            promise.reject("E_BT_SCAN", message)
-          }
-        }
 
     try {
       Log.d(NAME, "Going to scan bluetooth")
@@ -476,32 +499,32 @@ class ZebraLinkosModule internal constructor(reactContext: ReactApplicationConte
     }
 
     val discoveryHandler =
-        object : DiscoveryHandler {
-          val printers = Arguments.createArray()
+            object : DiscoveryHandler {
+              val printers = Arguments.createArray()
 
-          override fun foundPrinter(printer: DiscoveredPrinter) {
-            try {
-              val printerBluetoothLe = printer as DiscoveredPrinterBluetoothLe
-              this.printers.pushMap(convertToWritableMap(printerBluetoothLe))
-              Log.d(NAME, "Found printer: ${printerBluetoothLe.friendlyName}")
-            } catch (e: Exception) {
-              Log.e(NAME, "Error adding printer to list: ${e.localizedMessage}")
-              promise.reject("E_BLE_SCAN", e.localizedMessage, e)
-              e.localizedMessage?.let { Log.e(NAME, it) }
-              e.printStackTrace()
+              override fun foundPrinter(printer: DiscoveredPrinter) {
+                try {
+                  val printerBluetoothLe = printer as DiscoveredPrinterBluetoothLe
+                  this.printers.pushMap(convertToWritableMap(printerBluetoothLe))
+                  Log.d(NAME, "Found printer: ${printerBluetoothLe.friendlyName}")
+                } catch (e: Exception) {
+                  Log.e(NAME, "Error adding printer to list: ${e.localizedMessage}")
+                  promise.reject("E_BLE_SCAN", e.localizedMessage, e)
+                  e.localizedMessage?.let { Log.e(NAME, it) }
+                  e.printStackTrace()
+                }
+              }
+
+              override fun discoveryFinished() {
+                Log.d(NAME, "Discovery finished")
+                promise.resolve(this.printers)
+              }
+
+              override fun discoveryError(message: String?) {
+                Log.e(NAME, "Bluetooth discovery error: $message")
+                promise.reject("E_BLE_SCAN", message)
+              }
             }
-          }
-
-          override fun discoveryFinished() {
-            Log.d(NAME, "Discovery finished")
-            promise.resolve(this.printers)
-          }
-
-          override fun discoveryError(message: String?) {
-            Log.e(NAME, "Bluetooth discovery error: $message")
-            promise.reject("E_BLE_SCAN", message)
-          }
-        }
 
     try {
       Log.d(NAME, "Going to scan bluetooth LE")
@@ -526,32 +549,32 @@ class ZebraLinkosModule internal constructor(reactContext: ReactApplicationConte
     }
 
     val discoveryHandler =
-        object : DiscoveryHandler {
-          val printers = Arguments.createArray()
+            object : DiscoveryHandler {
+              val printers = Arguments.createArray()
 
-          override fun foundPrinter(printer: DiscoveredPrinter) {
-            try {
-              val printerUSB = printer as DiscoveredPrinterUsb
-              this.printers.pushMap(convertToWritableMap(printerUSB))
-              Log.d(NAME, "Found USB printer: ${printerUSB.address}")
-            } catch (e: Exception) {
-              Log.e(NAME, "Error adding USB printer to list: ${e.localizedMessage}")
-              promise.reject("E_USB_SCAN", e.localizedMessage, e)
-              e.localizedMessage?.let { Log.e(NAME, it) }
-              e.printStackTrace()
+              override fun foundPrinter(printer: DiscoveredPrinter) {
+                try {
+                  val printerUSB = printer as DiscoveredPrinterUsb
+                  this.printers.pushMap(convertToWritableMap(printerUSB))
+                  Log.d(NAME, "Found USB printer: ${printerUSB.address}")
+                } catch (e: Exception) {
+                  Log.e(NAME, "Error adding USB printer to list: ${e.localizedMessage}")
+                  promise.reject("E_USB_SCAN", e.localizedMessage, e)
+                  e.localizedMessage?.let { Log.e(NAME, it) }
+                  e.printStackTrace()
+                }
+              }
+
+              override fun discoveryFinished() {
+                Log.d(NAME, "USB discovery finished")
+                promise.resolve(this.printers)
+              }
+
+              override fun discoveryError(message: String?) {
+                Log.e(NAME, "USB discovery error: $message")
+                promise.reject("E_USB_SCAN", message)
+              }
             }
-          }
-
-          override fun discoveryFinished() {
-            Log.d(NAME, "USB discovery finished")
-            promise.resolve(this.printers)
-          }
-
-          override fun discoveryError(message: String?) {
-            Log.e(NAME, "USB discovery error: $message")
-            promise.reject("E_USB_SCAN", message)
-          }
-        }
 
     try {
       Log.d(NAME, "Going to scan USB")
@@ -565,8 +588,8 @@ class ZebraLinkosModule internal constructor(reactContext: ReactApplicationConte
   }
 
   private fun convertStatusToWritableMap(
-      printerAddress: String,
-      status: PrinterStatus
+          printerAddress: String,
+          status: PrinterStatus
   ): WritableMap {
     val map = Arguments.createMap()
     map.putString("address", printerAddress)
@@ -598,7 +621,6 @@ class ZebraLinkosModule internal constructor(reactContext: ReactApplicationConte
       val printerStatus = printer.currentStatus
 
       val printerStatusMap = convertStatusToWritableMap(ipAddress, printerStatus)
-
 
       promise.resolve(printerStatusMap)
     } catch (e: ConnectionException) {
@@ -694,21 +716,29 @@ class ZebraLinkosModule internal constructor(reactContext: ReactApplicationConte
       if (!usbReceiverRegistered) {
         val filter = IntentFilter(ACTION_USB_PERMISSION)
         ContextCompat.registerReceiver(
-            reactApplicationContext, usbReceiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
+                reactApplicationContext,
+                usbReceiver,
+                filter,
+                ContextCompat.RECEIVER_NOT_EXPORTED
+        )
         usbReceiverRegistered = true
       }
 
       val explicitIntent =
-          Intent(ACTION_USB_PERMISSION).apply {
-            setPackage(reactApplicationContext.packageName)
-            putExtra(UsbManager.EXTRA_DEVICE, device)
-            putExtra("Mode", "Status")
-            putExtra("deviceId", deviceId)
-          }
+              Intent(ACTION_USB_PERMISSION).apply {
+                setPackage(reactApplicationContext.packageName)
+                putExtra(UsbManager.EXTRA_DEVICE, device)
+                putExtra("Mode", "Status")
+                putExtra("deviceId", deviceId)
+              }
 
       val permissionIntent =
-          PendingIntent.getBroadcast(
-              reactApplicationContext, 0, explicitIntent, PendingIntent.FLAG_MUTABLE)
+              PendingIntent.getBroadcast(
+                      reactApplicationContext,
+                      0,
+                      explicitIntent,
+                      PendingIntent.FLAG_MUTABLE
+              )
 
       usbManager.requestPermission(device, permissionIntent)
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-zebra-linkos",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Zebra LinkOS integration for React Native",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",
@@ -42,7 +42,7 @@
     "typecheck": "tsc",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "clean": "del-cli android/build example/android/build example/android/app/build example/ios/build lib",
-    "prepare": "bob build",
+    "postinstall": "npx -y react-native-builder-bob build",
     "release": "release-it"
   },
   "keywords": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "jsx": "react-jsx",
     "lib": ["ESNext"],
     "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "moduleResolution": "node",
     "noEmit": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
## Problem

When installing `react-native-zebra-linkos` directly from GitHub (e.g., `yarn add react-native-zebra-linkos`), the `lib/` directory is not built because `react-native-builder-bob` is in `devDependencies` and may not be available.

This causes Metro to fail with:

```
The package .../react-native-zebra-linkos contains an invalid package.json configuration.
The resolution for "." in "exports" is `./lib/module/index.js`, but this file does not exist.
```

## Fix

Replace `prepare` with `postinstall` and use `npx -y` to run `react-native-builder-bob`:

```diff
-"prepare": "bob build",
+"postinstall": "npx -y react-native-builder-bob build",
```

**Why `postinstall` over `prepare`**: `prepare` is a pre-publish hook that runs before npm publishes, requiring devDependencies. `postinstall` runs after **every** install regardless of devDependencies, and `npx -y` downloads `bob` on-demand so it works even when devDependencies are skipped (common with pnpm workspaces).

## Version

Bump `0.2.0` → `0.2.1`

## Environment

- **Package manager tested**: pnpm 9.x, yarn 3.x
- **react-native-builder-bob**: ^0.30.2
