### PR TITLE
fix(android): fix duplicate META-INF/DEPENDENCIES in build-android

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -41,3 +41,17 @@ allprojects {
         google()
     }
 }
+
+android {
+    packaging {
+        resources {
+            excludes += [
+                "META-INF/DEPENDENCIES",
+                "META-INF/NOTICE",
+                "META-INF/LICENSE",
+                "META-INF/LICENSE.txt",
+                "META-INF/NOTICE.txt"
+            ]
+        }
+    }
+}

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -42,16 +42,18 @@ allprojects {
     }
 }
 
-android {
-    packaging {
-        resources {
-            excludes += [
-                "META-INF/DEPENDENCIES",
-                "META-INF/NOTICE",
-                "META-INF/LICENSE",
-                "META-INF/LICENSE.txt",
-                "META-INF/NOTICE.txt"
-            ]
+afterEvaluate {
+    android {
+        packaging {
+            resources {
+                excludes += [
+                    "META-INF/DEPENDENCIES",
+                    "META-INF/NOTICE",
+                    "META-INF/LICENSE",
+                    "META-INF/LICENSE.txt",
+                    "META-INF/NOTICE.txt"
+                ]
+            }
         }
     }
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -42,18 +42,12 @@ allprojects {
     }
 }
 
-afterEvaluate {
-    android {
-        packaging {
-            resources {
-                excludes += [
-                    "META-INF/DEPENDENCIES",
-                    "META-INF/NOTICE",
-                    "META-INF/LICENSE",
-                    "META-INF/LICENSE.txt",
-                    "META-INF/NOTICE.txt"
-                ]
-            }
-        }
+android {
+    packagingOptions {
+        exclude 'META-INF/DEPENDENCIES'
+        exclude 'META-INF/NOTICE'
+        exclude 'META-INF/LICENSE'
+        exclude 'META-INF/LICENSE.txt'
+        exclude 'META-INF/NOTICE.txt'
     }
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -42,12 +42,18 @@ allprojects {
     }
 }
 
-android {
-    packagingOptions {
-        exclude 'META-INF/DEPENDENCIES'
-        exclude 'META-INF/NOTICE'
-        exclude 'META-INF/LICENSE'
-        exclude 'META-INF/LICENSE.txt'
-        exclude 'META-INF/NOTICE.txt'
+subprojects {
+    afterEvaluate {
+        if (project.extensions.findByName("android") != null) {
+            android {
+                packagingOptions {
+                    exclude 'META-INF/DEPENDENCIES'
+                    exclude 'META-INF/NOTICE'
+                    exclude 'META-INF/LICENSE'
+                    exclude 'META-INF/LICENSE.txt'
+                    exclude 'META-INF/NOTICE.txt'
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Problem

The `build-android` CI job fails because `mergeDebugJavaResource` finds 3 JAR files containing duplicate `META-INF/DEPENDENCIES`:

- `httpmime-4.5.14.jar`
- `httpclient-4.5.14.jar`
- `httpcore-4.4.16.jar`

## Fix

Add `packagingOptions` via a `subprojects { afterEvaluate { ... } }` block to `example/android/build.gradle`:

```gradle
subprojects {
    afterEvaluate {
        if (project.extensions.findByName("android") != null) {
            android {
                packagingOptions {
                    exclude 'META-INF/DEPENDENCIES'
                    exclude 'META-INF/NOTICE'
                    exclude 'META-INF/LICENSE'
                    exclude 'META-INF/LICENSE.txt'
                    exclude 'META-INF/NOTICE.txt'
                }
            }
        }
    }
}
```

## Root Cause

The library's `android/build.gradle` already has `packagingOptions { exclude 'META-INF/DEPENDENCIES' }`, but the example app (managed by `react-native-test-app`) didn't inherit this.

`react-native-test-app` applies the Android plugin dynamically via `applyTestAppSettings(settings)` in `settings.gradle`. The app-level `build.gradle` is generated at runtime, so the Android extension doesn't exist at the time the root `build.gradle` is evaluated. Using `subprojects { afterEvaluate { ... } }` ensures the `android` extension exists before we try to modify it.

## History

- Attempt 1: `android { packaging { resources { excludes } } }` — failed: "Could not find method android()"
- Attempt 2: `afterEvaluate { android { packaging { ... } } }` — failed: "Could not find method android()"
- Attempt 3: `android { packagingOptions { ... } }` — failed: "Could not find method android()"
- Attempt 4: `subprojects { afterEvaluate { if (project.extensions.findByName("android") != null) { android { ... } } } }` — uses legacy DSL on subprojects after the Android extension is available
