### PR TITLE
Fix iOS Build Error and CI Warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,27 +70,30 @@ jobs:
             ${{ runner.os }}-turborepo-android-
 
       - name: Check turborepo cache for Android
+        id: check-turbo-cache
         run: |
           TURBO_CACHE_STATUS=$(node -p "($(yarn turbo run build:android --cache-dir="${{ env.TURBO_CACHE_DIR }}" --dry=json)).tasks.find(t => t.task === 'build:android').cache.status")
 
           if [[ $TURBO_CACHE_STATUS == "HIT" ]]; then
-            echo "turbo_cache_hit=1" >> $GITHUB_ENV
+            echo "hit=true" >> $GITHUB_OUTPUT
+          else
+            echo "hit=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Install JDK
-        if: env.turbo_cache_hit != 1
+        if: steps.check-turbo-cache.outputs.hit != 'true'
         uses: actions/setup-java@v3
         with:
           distribution: "zulu"
           java-version: "17"
 
       - name: Finalize Android SDK
-        if: env.turbo_cache_hit != 1
+        if: steps.check-turbo-cache.outputs.hit != 'true'
         run: |
           /bin/bash -c "yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses > /dev/null"
 
       - name: Cache Gradle
-        if: env.turbo_cache_hit != 1
+        if: steps.check-turbo-cache.outputs.hit != 'true'
         uses: actions/cache@v3
         with:
           path: |
@@ -128,15 +131,18 @@ jobs:
             ${{ runner.os }}-turborepo-ios-
 
       - name: Check turborepo cache for iOS
+        id: check-turbo-cache
         run: |
           TURBO_CACHE_STATUS=$(node -p "($(yarn turbo run build:ios --cache-dir="${{ env.TURBO_CACHE_DIR }}" --dry=json)).tasks.find(t => t.task === 'build:ios').cache.status")
 
           if [[ $TURBO_CACHE_STATUS == "HIT" ]]; then
-            echo "turbo_cache_hit=1" >> $GITHUB_ENV
+            echo "hit=true" >> $GITHUB_OUTPUT
+          else
+            echo "hit=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Cache cocoapods
-        if: env.turbo_cache_hit != 1
+        if: steps.check-turbo-cache.outputs.hit != 'true'
         id: cocoapods-cache
         uses: actions/cache@v3
         with:
@@ -147,8 +153,8 @@ jobs:
             ${{ runner.os }}-cocoapods-
 
       - name: Install cocoapods
-        if: env.turbo_cache_hit != 1 && steps.cocoapods-cache.outputs.cache-hit !=
-          'true'
+        if: steps.check-turbo-cache.outputs.hit != 'true' &&
+          steps.cocoapods-cache.outputs.cache-hit != 'true'
         run: |
           cd example/ios
           pod install --repo-update
@@ -156,8 +162,8 @@ jobs:
           NO_FLIPPER: 1
 
       - name: Generate Podfile.lock for caching
-        if: env.turbo_cache_hit != 1 && steps.cocoapods-cache.outputs.cache-hit !=
-          'true'
+        if: steps.check-turbo-cache.outputs.hit != 'true' &&
+          steps.cocoapods-cache.outputs.cache-hit != 'true'
         run: |
           cd example/ios
           pod install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,9 +151,16 @@ jobs:
           'true'
         run: |
           cd example/ios
-          pod install
+          pod install --repo-update
         env:
           NO_FLIPPER: 1
+
+      - name: Generate Podfile.lock for caching
+        if: env.turbo_cache_hit != 1 && steps.cocoapods-cache.outputs.cache-hit !=
+          'true'
+        run: |
+          cd example/ios
+          pod install
 
       - name: Build example for iOS
         run: |

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -9,3 +9,6 @@ require "#{ws_dir}/node_modules/react-native-test-app/test_app.rb"
 workspace 'ZebraLinkosExample.xcworkspace'
 
 use_test_app!
+
+# Explicitly include the native module
+pod 'react-native-zebra-linkos', :path => '../..'

--- a/example/package.json
+++ b/example/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "android": "react-native run-android",
     "build:android": "npm run mkdist && react-native bundle --entry-file index.js --platform android --dev true --bundle-output dist/main.android.jsbundle --assets-dest dist && react-native build-android --extra-params \"--no-daemon --console=plain -PreactNativeArchitectures=arm64-v8a\"",
-    "build:ios": "npm run mkdist && react-native bundle --entry-file index.js --platform ios --dev true --bundle-output dist/main.ios.jsbundle --assets-dest dist && cd example/ios && xcodebuild -workspace ZebraLinkosExample.xcworkspace -configuration Debug -scheme ZebraLinkosExample -destination 'generic/platform=iOS Simulator' -sdk iphonesimulator COMPILER_INDEX_STORE_ENABLE=NO",
+    "build:ios": "npm run mkdist && react-native bundle --entry-file index.js --platform ios --dev true --bundle-output dist/main.ios.jsbundle --assets-dest dist && cd ios && xcodebuild -workspace ZebraLinkosExample.xcworkspace -configuration Debug -scheme ZebraLinkosExample -destination 'generic/platform=iOS Simulator' -sdk iphonesimulator COMPILER_INDEX_STORE_ENABLE=NO",
     "ios": "react-native run-ios",
     "mkdist": "node -e \"require('node:fs').mkdirSync('dist', { recursive: true, mode: 0o755 })\"",
     "start": "react-native start"

--- a/example/package.json
+++ b/example/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "android": "react-native run-android",
     "build:android": "npm run mkdist && react-native bundle --entry-file index.js --platform android --dev true --bundle-output dist/main.android.jsbundle --assets-dest dist && react-native build-android --extra-params \"--no-daemon --console=plain -PreactNativeArchitectures=arm64-v8a\"",
-    "build:ios": "npm run mkdist && react-native bundle --entry-file index.js --platform ios --dev true --bundle-output dist/main.ios.jsbundle --assets-dest dist && react-native build-ios --scheme RnScheduleClearCacheExample --mode Debug --extra-params \"-sdk iphonesimulator CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ GCC_OPTIMIZATION_LEVEL=0 GCC_PRECOMPILE_PREFIX_HEADER=YES ASSETCATALOG_COMPILER_OPTIMIZATION=time DEBUG_INFORMATION_FORMAT=dwarf COMPILER_INDEX_STORE_ENABLE=NO\"",
+    "build:ios": "npm run mkdist && react-native bundle --entry-file index.js --platform ios --dev true --bundle-output dist/main.ios.jsbundle --assets-dest dist && cd example/ios && xcodebuild -workspace ZebraLinkosExample.xcworkspace -configuration Debug -scheme ZebraLinkosExample -destination 'generic/platform=iOS Simulator' -sdk iphonesimulator COMPILER_INDEX_STORE_ENABLE=NO",
     "ios": "react-native run-ios",
     "mkdist": "node -e \"require('node:fs').mkdirSync('dist', { recursive: true, mode: 0o755 })\"",
     "start": "react-native start"


### PR DESCRIPTION
# Fix iOS Build Error and CI Warning

## Summary

This PR addresses two critical issues preventing successful iOS builds:

1. **iOS Build Failure (xcodebuild error 65)** - Caused by incorrect Xcode scheme name and missing pod reference
2. **GitHub Actions Warning** - Invalid context access for `turbo_cache_hit` variable

## Changes

### 1. Fix iOS Build Scheme Name (`example/package.json`)

- Changed scheme from `RnScheduleClearCacheExample` to `ZebraLinkosExample`
- Switched from `react-native build-ios` to direct `xcodebuild` command
- **Fixes**: `xcodebuild` exited with error code '65'

### 2. Add Pod to iOS Podfile (`example/ios/Podfile`)

- Added `pod 'react-native-zebra-linkos', :path => '../..'`
- Ensures native module is explicitly included regardless of `use_test_app!` auto-discovery behavior

### 3. Improve CI Caching (`example/package.json` build:ios script)

- Added `--repo-update` to `pod install` to ensure podspecs are up-to-date
- Added "Generate Podfile.lock for caching" step to ensure Podfile.lock exists after pod install

### 4. Fix GitHub Actions Warning (`ci.yml`)

**Problem**: `Context access might be invalid: turbo_cache_hit`

**Root Cause**: The variable was set via `$GITHUB_ENV` in a `run` step, but accessed in `if` conditions before GitHub could guarantee its existence at evaluation time.

**Solution**: Changed from environment variables to **step outputs**:

- Added `id: check-turbo-cache` to the cache-check step
- Changed output from `echo "turbo_cache_hit=1" >> $GITHUB_ENV` to `echo "hit=true" >> $GITHUB_OUTPUT`
- Updated all conditions from `if: env.turbo_cache_hit != 1` to `if: steps.check-turbo-cache.outputs.hit != 'true'`

## Commits

```
c218be0 ci: fix GitHub Actions turbo_cache_hit context access warning
11ddb36 ci: fix iOS Podfile.lock caching and add --repo-update to pod install
24dca67 fix: explicitly include react-native-zebra-linkos pod in Podfile
a98a71a fix: use correct Xcode scheme name for iOS build
```

## Verification

- [ ] CI passes with iOS build job
- [ ] No more "Context access might be invalid" warnings in CI
- [ ] Android build continues to work as expected
