### PR TITLE
chore: rename package to @viska-io/react-native-zebra-linkos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,8 @@ To publish new versions, run the following:
 yarn release
 ```
 
+> Note: This package is published to GitHub Packages under the `@viska-io` scope. Ensure you have authenticated with `npm.pkg.github.com` before publishing.
+
 ### Scripts
 
 The `package.json` file contains various scripts for common tasks:

--- a/README.md
+++ b/README.md
@@ -1,24 +1,22 @@
-# react-native-zebra-linkos
+# @viska-io/react-native-zebra-linkos
 
 Zebra LinkOS integration for React Native
 
 ## Installation
 
 ```sh
-npm install react-native-zebra-linkos
+npm install @viska-io/react-native-zebra-linkos
 ```
 
 ## Usage
 
-
 ```js
-import { multiply } from 'react-native-zebra-linkos';
+import { writeTCP, scanNetwork } from '@viska-io/react-native-zebra-linkos';
 
 // ...
 
 const result = multiply(3, 7);
 ```
-
 
 ## Contributing
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -22,12 +22,12 @@ import {
   checkBTPrinterStatus,
   checkTCPPrinterStatus,
   checkUSBPrinterStatus,
-} from 'react-native-zebra-linkos';
+} from '@viska-io/react-native-zebra-linkos';
 import type {
   DiscoveredPrinter,
   DiscoveredPrinterBluetooth,
   DiscoveredPrinterBluetoothLe,
-} from 'react-native-zebra-linkos';
+} from '@viska-io/react-native-zebra-linkos';
 import type { PrinterStatus } from '../../src/@types';
 
 const App = () => {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-zebra-linkos",
+  "name": "@viska-io/react-native-zebra-linkos",
   "version": "0.2.2",
   "description": "Zebra LinkOS integration for React Native",
   "source": "./src/index.tsx",
@@ -52,16 +52,16 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/scantarbian/react-native-zebra-linkos.git"
+    "url": "git+https://github.com/VISKA-IO/react-native-zebra-linkos.git"
   },
   "author": "scantarbian <davidpamereanb@gmail.com> (https://github.com/scantarbian)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/scantarbian/react-native-zebra-linkos/issues"
+    "url": "https://github.com/VISKA-IO/react-native-zebra-linkos/issues"
   },
-  "homepage": "https://github.com/scantarbian/react-native-zebra-linkos#readme",
+  "homepage": "https://github.com/VISKA-IO/react-native-zebra-linkos#readme",
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^17.0.2",

--- a/react-native-zebra-linkos.podspec
+++ b/react-native-zebra-linkos.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.authors      = package["author"]
 
   s.platforms    = { :ios => min_ios_version_supported }
-  s.source       = { :git => "https://github.com/scantarbian/react-native-zebra-linkos.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/VISKA-IO/react-native-zebra-linkos.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm}"
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,7 +10,7 @@ import type {
 import { NativeModules, Platform } from 'react-native';
 
 const LINKING_ERROR =
-  `The package 'react-native-zebra-linkos' doesn't seem to be linked. Make sure:\n\n` +
+  `The package '@viska-io/react-native-zebra-linkos' doesn't seem to be linked. Make sure:\n\n` +
   Platform.select({ ios: "- You have run 'pod install'\n", default: '' }) +
   '- You rebuilt the app after installing the package\n' +
   '- You are not using Expo Go\n';


### PR DESCRIPTION
This PR renames the package from `react-native-zebra-linkos` to `@viska-io/react-native-zebra-linkos` to align with the VISKA-IO organization.

Changes include:
- Package name in `package.json`
- Repository URLs and bug tracker URLs
- `publishConfig.registry` set to `https://npm.pkg.github.com` for GitHub Packages
- Podspec git source URL
- Import string in `src/index.tsx`
- Example app imports in `example/src/App.tsx`
- README.md and CONTRIBUTING.md references
- Git remote URL updated to VISKA-IO organization